### PR TITLE
HtmlAttributes can receive a Dictionary

### DIFF
--- a/TwitterBootstrapMVC/Controls/BootstrapTextBox.cs
+++ b/TwitterBootstrapMVC/Controls/BootstrapTextBox.cs
@@ -51,6 +51,12 @@ namespace TwitterBootstrapMVC.Controls
             return (T)this;
         }
 
+        public T HtmlAttributes(IDictionary<string, object> htmlAttributes)
+        {
+            this._model.htmlAttributes = htmlAttributes;
+            return (T)this;
+        }
+
         public T HtmlAttributes(object htmlAttributes)
         {
             this._model.htmlAttributes = htmlAttributes.ToDictionary();


### PR DESCRIPTION
Added a overload to HtmlAttributes on BootstrapTextBox to accept a Dictionary as parameter.
Since the internal variable is already a Dictionary is not a big problem, just a facility to who already is working with dictionaries and don´t need to create a object on every call inside a view.
